### PR TITLE
Support for native npm arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,4 @@ Before executing ensure, that you have installed the dependencies/run `npm insta
 * `--peerDepFilter`: regex pattern to install only peerDependencies matching the pattern
 * `--dryRun`: skip the install step. 
 * `--force`: install peerDependencies regardless if they are already part of your package.json and therefore already installed.
-* `--dev`: use devDependencies instead of dependencies
+* Any argument used with `npm install` (ex. `--save-dev`, `--no-save`, `--save`, ...)

--- a/index.js
+++ b/index.js
@@ -123,8 +123,24 @@ module.exports = () => {
             console.warn('dry run => will not install', ...installList)
             return
         }
+
+        const { cwd } = args;
+
+        // Legacy support for --dev argument
+        if (args.dev) {
+            args['save-dev'] = true;
+        }
+
+        // Remove custom arguments
+        delete args.cwd
+        delete args.depFilter
+        delete args.peerDepFilter
+        delete args.force
+        delete args.dev
+        delete args._
+
         console.log('will install', installList)
-        installDependencies(installList, args.cwd, dependencyType)
+        installDependencies(installList, cwd, args)
     } else {
         console.log('no peerDependencies to install')
     }

--- a/lib/npm-install.action.js
+++ b/lib/npm-install.action.js
@@ -1,12 +1,8 @@
 const spawn = require('cross-spawn')
-const dependencyTypes = require('./dependency-types')
-module.exports = (deps, cwd, dependencyType) => {
 
-    let args = ['install', ...deps]
-    if (dependencyType === dependencyTypes.devDependencies) {
-        args = ['install', '-D', ...deps]
-    }
-    const npmInstall = spawn('npm', args, { cwd })
+module.exports = (deps, cwd, args) => {
+    const argsArray = Object.keys(args).map((argKey) => `--${argKey}=${args[argKey]}`)
+    const npmInstall = spawn('npm', ['install', ...deps, ...argsArray], { cwd })
 
     npmInstall.stdout.on('data', (data) => {
         console.log(`${data}`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "transitive-peerdeps",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitive-peerdeps",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "List and install peerDependencies of your direct dependencies",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "transitive-peerdeps",
-  "version": "0.4.0"
+  "version": "0.4.0",
   "description": "List and install peerDependencies of your direct dependencies",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
I've added support for native npm arguments.  

This is needed for version 7+ of NPM where installed packages are saved as dependencies by default. With this feature people can now add `--no-save` in order to not save the peer dependencies.  

I also removed the `--dev` argument since now people can use `--save-dev` or `-D`. I however added legacy support for it.